### PR TITLE
[Hotfix] ListAuthenticators should be a GET request instead of POST

### DIFF
--- a/management/user.go
+++ b/management/user.go
@@ -446,6 +446,6 @@ func (m *UserManager) Enrollments(id string) (enrols []*UserEnrollment, err erro
 //
 // It's an undocumented API, see: https://community.auth0.com/t/when-will-api-v2-users-userid-authenticators-be-documented/52722
 func (m *UserManager) ListAuthenticators(id string) (enrols []*UserAuthenticator, err error) {
-	err = m.request("POST", m.uri("users", id, "authenticators"), &enrols)
+	err = m.request("GET", m.uri("users", id, "authenticators"), &enrols)
 	return enrols, err
 }


### PR DESCRIPTION
I got the error below when calling the endpoint:

```
rpc error: code = Internal desc = error fetching user authenticators from Auth0: list authenticators failed with status code 2: 404 Not Found: Not Found
```

I've tested using POST with Postman and end up with the same 404 error, but with GET, I can get results.